### PR TITLE
Potential fix for code scanning alert no. 66: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-license.yml
+++ b/.github/workflows/update-license.yml
@@ -2,6 +2,9 @@ permissions:
   contents: write
   pull-requests: write
 name: Update copyright year in license file
+permissions:
+  contents: write
+  pull-requests: write
 
 on:
   schedule:

--- a/.github/workflows/update-license.yml
+++ b/.github/workflows/update-license.yml
@@ -1,7 +1,5 @@
-permissions:
-  contents: write
-  pull-requests: write
 name: Update copyright year in license file
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/update-license.yml
+++ b/.github/workflows/update-license.yml
@@ -1,3 +1,6 @@
+permissions:
+  contents: write
+  pull-requests: write
 name: Update copyright year in license file
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/dailydevops/pipelines/security/code-scanning/66](https://github.com/dailydevops/pipelines/security/code-scanning/66)

To fix the problem, we should add a `permissions` block to the workflow. Since the workflow creates and merges pull requests, it needs `contents: write` and `pull-requests: write` permissions. The minimal starting point suggested by CodeQL is `contents: read`, but in this case, the workflow needs to create commits and merge PRs, so `write` permissions for `contents` and `pull-requests` are required. The best way to fix this is to add the `permissions` block at the top level of the workflow (before `jobs:`), so it applies to all jobs. Edit the `.github/workflows/update-license.yml` file to insert the following block after the `name:` and before `on:`:

```yaml
permissions:
  contents: write
  pull-requests: write
```

No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
