### PR TITLE
perf(ci): add NuGet caching and shallow checkouts to speed up PR runs

### DIFF
--- a/.github/workflows/build-dotnet-fast.yml
+++ b/.github/workflows/build-dotnet-fast.yml
@@ -91,7 +91,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props', '**/Directory.Build.props') }}
           restore-keys: |
             ${{ runner.os }}-nuget-
 

--- a/.github/workflows/step-collect-matrix.yml
+++ b/.github/workflows/step-collect-matrix.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
-        fetch-depth: 0
+        fetch-depth: 1
         submodules: recursive
         token: ${{ secrets.FETCH_TOKEN || github.token }}
 

--- a/.github/workflows/step-dotnet-build.yml
+++ b/.github/workflows/step-dotnet-build.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
-        fetch-depth: 0
+        fetch-depth: 1
         submodules: recursive
         token: ${{ secrets.FETCH_TOKEN || github.token }}
 
@@ -48,6 +48,14 @@ jobs:
       with:
         dotnet-version: ${{ inputs.dotnet-version }}
         global-json-file: ./global.json
+
+    - name: NuGet cache
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props', '**/Directory.Build.props') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
 
     - name: Restore dependencies
       run: dotnet restore ${{ inputs.solution }} -v ${{ inputs.dotnet-logging }}

--- a/.github/workflows/step-dotnet-format.yml
+++ b/.github/workflows/step-dotnet-format.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
-        fetch-depth: 0
+        fetch-depth: 1
         submodules: recursive
         token: ${{ secrets.FETCH_TOKEN || github.token }}
 

--- a/.github/workflows/step-dotnet-tests.yml
+++ b/.github/workflows/step-dotnet-tests.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
-        fetch-depth: 0
+        fetch-depth: 1
         submodules: recursive
         token: ${{ secrets.FETCH_TOKEN || github.token }}
 
@@ -106,6 +106,14 @@ jobs:
       with:
         dotnet-version: ${{ inputs.dotnet-version }}
         global-json-file: ./global.json
+
+    - name: NuGet cache
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props', '**/Directory.Build.props') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
 
     - name: Restore dependencies
       run: dotnet restore ${{ inputs.solution }} -v ${{ inputs.dotnet-logging }}


### PR DESCRIPTION
## Motivation

With ~20 parallel agents, concurrent PRs quickly saturate the runner pool. A single PR in a consumer repo like `healthchecks` spawns ~11 jobs, each doing a full-history checkout and a full NuGet restore. This PR reduces per-job time without changing any functionality.

## Changes

### NuGet caching (`step-dotnet-tests.yml`, `step-dotnet-build.yml`)
- Add `actions/cache` for `~/.nuget/packages`, matching the existing cache in `build-dotnet-fast.yml`.
- Cache key now includes `Directory.Packages.props` and `Directory.Build.props` in addition to `**/*.csproj`, since package versions are usually managed centrally (also applied to the existing cache in `build-dotnet-fast.yml`).
- `restore-keys` fallback keeps partial cache hits on key miss.

### Shallow checkouts (`fetch-depth: 1`)
Applied where full git history is not needed:
- `step-dotnet-tests.yml`
- `step-dotnet-build.yml`
- `step-dotnet-format.yml`
- `step-collect-matrix.yml`

Unchanged (history required):
- `step-dotnet-version.yml` — GitVersion needs full history
- `step-node-commitlint.yml` — validates PR commit history

## Impact per PR (e.g. healthchecks)

- 7 jobs (6 test matrix + build) restore from cache instead of downloading all packages
- 8 jobs check out shallow instead of full history
- Coverage reports, test scope, and versioning are unaffected