### PR TITLE
perf(ci): build solution once and reuse binaries in dynamic test matrix

### DIFF
--- a/.github/workflows/build-dotnet-dynamic.yml
+++ b/.github/workflows/build-dotnet-dynamic.yml
@@ -13,6 +13,10 @@ on:
         required: false
         type: boolean
         default: false
+      disablePrebuild:
+        required: false
+        type: boolean
+        default: false
       disableTestsOnLinux:
         required: false
         type: boolean
@@ -109,13 +113,30 @@ jobs:
       runs-on: ${{ inputs.runsOnBuild || 'ubuntu-latest' }}
     secrets: inherit
 
+  prebuild:
+    name: Prebuild Solution
+    if: ${{ !inputs.disablePrebuild && !inputs.disableTestsOnLinux }}
+    uses: ./.github/workflows/step-dotnet-prebuild.yml
+    needs:
+      - commitlinter
+      - version
+    with:
+      dotnet-logging: ${{ inputs.dotnetLogging || 'minimal' }}
+      dotnet-version: ${{ inputs.dotnetVersion || '8.x' }}
+      runs-on: ${{ inputs.runsOnBuild || 'ubuntu-latest' }}
+      solution: ${{ inputs.solution }}
+      solution-version: ${{ needs.version.outputs.solution-version }}
+    secrets: inherit
+
   tests:
     name: Run Tests
+    if: ${{ !cancelled() && !failure() }}
     uses: ./.github/workflows/step-dotnet-tests.yml
     needs:
       - commitlinter
       - version
       - collect
+      - prebuild
     strategy:
       fail-fast: ${{ inputs.failFast }}
       matrix:
@@ -135,6 +156,7 @@ jobs:
       dotnet-version: ${{ inputs.dotnetVersion || '8.x' }}
       enableCleanUpDockerDocker: ${{ inputs.enableCleanUpDockerDocker || false }}
       execution-name: ${{ matrix.test-filter }}
+      prebuilt-artifact: ${{ needs.prebuild.outputs.artifact-name }}
       runs-on: ${{ matrix.os }}
       solution: ${{ inputs.solution }}
       solution-version: ${{ needs.version.outputs.solution-version }}

--- a/.github/workflows/build-dotnet-dynamic.yml
+++ b/.github/workflows/build-dotnet-dynamic.yml
@@ -178,9 +178,11 @@ jobs:
       solution: ${{ inputs.solution }}
       solution-version: ${{ needs.version.outputs.solution-version }}
     secrets: inherit
-  # Best-effort deletion of the prebuilt artifact once all test jobs are done,
-  # regardless of their outcome. Requires `actions: write` on the caller's
-  # GITHUB_TOKEN; without it the artifact simply expires via retention-days.
+  # Best-effort cleanup of the prebuilt artifact once all test jobs are done,
+  # regardless of their outcome. Deleting via the REST API would require
+  # 'actions: write' on the caller's GITHUB_TOKEN (and break callers without
+  # it at startup), so the large artifact is instead replaced by a tiny
+  # placeholder via 'overwrite: true', which only needs the runtime token.
   cleanup-prebuilt:
     name: Cleanup Prebuilt Artifact
     if: ${{ always() && needs.prebuild.result == 'success' }}
@@ -188,18 +190,15 @@ jobs:
     needs:
       - prebuild
       - tests
-    permissions:
-      actions: write
     steps:
-      - name: Delete prebuilt artifact
+      - name: Create placeholder
+        run: echo "prebuilt output cleaned up after test execution" > cleaned-up.txt
+
+      - name: Replace prebuilt artifact with placeholder
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          artifact_id=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts?name=${{ needs.prebuild.outputs.artifact-name }}" -q '.artifacts[0].id')
-          if [ -n "$artifact_id" ] && [ "$artifact_id" != "null" ]; then
-            gh api -X DELETE "repos/${{ github.repository }}/actions/artifacts/$artifact_id"
-            echo "Deleted artifact ${{ needs.prebuild.outputs.artifact-name }} ($artifact_id)"
-          else
-            echo "Artifact ${{ needs.prebuild.outputs.artifact-name }} not found, nothing to delete"
-          fi
+        with:
+          name: ${{ needs.prebuild.outputs.artifact-name }}
+          path: cleaned-up.txt
+          retention-days: 1
+          overwrite: true

--- a/.github/workflows/build-dotnet-dynamic.yml
+++ b/.github/workflows/build-dotnet-dynamic.yml
@@ -178,3 +178,28 @@ jobs:
       solution: ${{ inputs.solution }}
       solution-version: ${{ needs.version.outputs.solution-version }}
     secrets: inherit
+  # Best-effort deletion of the prebuilt artifact once all test jobs are done,
+  # regardless of their outcome. Requires `actions: write` on the caller's
+  # GITHUB_TOKEN; without it the artifact simply expires via retention-days.
+  cleanup-prebuilt:
+    name: Cleanup Prebuilt Artifact
+    if: ${{ always() && needs.prebuild.result == 'success' }}
+    runs-on: ubuntu-latest
+    needs:
+      - prebuild
+      - tests
+    permissions:
+      actions: write
+    steps:
+      - name: Delete prebuilt artifact
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          artifact_id=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts?name=${{ needs.prebuild.outputs.artifact-name }}" -q '.artifacts[0].id')
+          if [ -n "$artifact_id" ] && [ "$artifact_id" != "null" ]; then
+            gh api -X DELETE "repos/${{ github.repository }}/actions/artifacts/$artifact_id"
+            echo "Deleted artifact ${{ needs.prebuild.outputs.artifact-name }} ($artifact_id)"
+          else
+            echo "Artifact ${{ needs.prebuild.outputs.artifact-name }} not found, nothing to delete"
+          fi

--- a/.github/workflows/build-dotnet-matrix.yml
+++ b/.github/workflows/build-dotnet-matrix.yml
@@ -177,9 +177,11 @@ jobs:
       solution-version: ${{ needs.version.outputs.solution-version }}
     secrets: inherit
 
-  # Best-effort deletion of the prebuilt artifact once all test jobs are done,
-  # regardless of their outcome. Requires `actions: write` on the caller's
-  # GITHUB_TOKEN; without it the artifact simply expires via retention-days.
+  # Best-effort cleanup of the prebuilt artifact once all test jobs are done,
+  # regardless of their outcome. Deleting via the REST API would require
+  # 'actions: write' on the caller's GITHUB_TOKEN (and break callers without
+  # it at startup), so the large artifact is instead replaced by a tiny
+  # placeholder via 'overwrite: true', which only needs the runtime token.
   cleanup-prebuilt:
     name: Cleanup Prebuilt Artifact
     if: ${{ always() && needs.prebuild.result == 'success' }}
@@ -187,18 +189,15 @@ jobs:
     needs:
       - prebuild
       - tests
-    permissions:
-      actions: write
     steps:
-      - name: Delete prebuilt artifact
+      - name: Create placeholder
+        run: echo "prebuilt output cleaned up after test execution" > cleaned-up.txt
+
+      - name: Replace prebuilt artifact with placeholder
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          artifact_id=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts?name=${{ needs.prebuild.outputs.artifact-name }}" -q '.artifacts[0].id')
-          if [ -n "$artifact_id" ] && [ "$artifact_id" != "null" ]; then
-            gh api -X DELETE "repos/${{ github.repository }}/actions/artifacts/$artifact_id"
-            echo "Deleted artifact ${{ needs.prebuild.outputs.artifact-name }} ($artifact_id)"
-          else
-            echo "Artifact ${{ needs.prebuild.outputs.artifact-name }} not found, nothing to delete"
-          fi
+        with:
+          name: ${{ needs.prebuild.outputs.artifact-name }}
+          path: cleaned-up.txt
+          retention-days: 1
+          overwrite: true

--- a/.github/workflows/build-dotnet-matrix.yml
+++ b/.github/workflows/build-dotnet-matrix.yml
@@ -13,6 +13,10 @@ on:
         required: false
         type: boolean
         default: false
+      disablePrebuild:
+        required: false
+        type: boolean
+        default: false
       disableTestsOnLinux:
         required: false
         type: boolean
@@ -111,12 +115,29 @@ jobs:
       runs-on: ${{ inputs.runsOnBuild || 'ubuntu-latest' }}
     secrets: inherit
 
+  prebuild:
+    name: Prebuild Solution
+    if: ${{ !inputs.disablePrebuild && !inputs.disableTestsOnLinux }}
+    uses: ./.github/workflows/step-dotnet-prebuild.yml
+    needs:
+      - commitlinter
+      - version
+    with:
+      dotnet-logging: ${{ inputs.dotnetLogging || 'minimal' }}
+      dotnet-version: ${{ inputs.dotnetVersion || '8.x' }}
+      runs-on: ${{ inputs.imageLinux || 'ubuntu-latest' }}
+      solution: ${{ inputs.solution }}
+      solution-version: ${{ needs.version.outputs.solution-version }}
+    secrets: inherit
+
   tests:
     name: Run Tests
+    if: ${{ !cancelled() && !failure() }}
     uses: ./.github/workflows/step-dotnet-tests.yml
     needs:
       - commitlinter
       - version
+      - prebuild
     strategy:
       fail-fast: ${{ inputs.failFast }}
       matrix:
@@ -134,6 +155,7 @@ jobs:
       dotnet-logging: ${{ inputs.dotnetLogging || 'minimal' }}
       dotnet-version: ${{ inputs.dotnetVersion || '8.x' }}
       enableCleanUpDockerDocker: ${{ inputs.enableCleanUpDockerDocker || false }}
+      prebuilt-artifact: ${{ needs.prebuild.outputs.artifact-name }}
       runs-on: ${{ matrix.os }}
       solution: ${{ inputs.solution }}
       solution-version: ${{ needs.version.outputs.solution-version }}
@@ -154,3 +176,29 @@ jobs:
       solution: ${{ inputs.solution }}
       solution-version: ${{ needs.version.outputs.solution-version }}
     secrets: inherit
+
+  # Best-effort deletion of the prebuilt artifact once all test jobs are done,
+  # regardless of their outcome. Requires `actions: write` on the caller's
+  # GITHUB_TOKEN; without it the artifact simply expires via retention-days.
+  cleanup-prebuilt:
+    name: Cleanup Prebuilt Artifact
+    if: ${{ always() && needs.prebuild.result == 'success' }}
+    runs-on: ubuntu-latest
+    needs:
+      - prebuild
+      - tests
+    permissions:
+      actions: write
+    steps:
+      - name: Delete prebuilt artifact
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          artifact_id=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts?name=${{ needs.prebuild.outputs.artifact-name }}" -q '.artifacts[0].id')
+          if [ -n "$artifact_id" ] && [ "$artifact_id" != "null" ]; then
+            gh api -X DELETE "repos/${{ github.repository }}/actions/artifacts/$artifact_id"
+            echo "Deleted artifact ${{ needs.prebuild.outputs.artifact-name }} ($artifact_id)"
+          else
+            echo "Artifact ${{ needs.prebuild.outputs.artifact-name }} not found, nothing to delete"
+          fi

--- a/.github/workflows/step-dotnet-prebuild.yml
+++ b/.github/workflows/step-dotnet-prebuild.yml
@@ -1,0 +1,87 @@
+on:
+  workflow_call:
+    inputs:
+      dotnet-logging:
+        required: false
+        type: string
+        default: quiet
+      dotnet-version:
+        required: false
+        type: string
+        default: 8.x
+      runs-on:
+        required: false
+        type: string
+        default: ubuntu-latest
+      solution:
+        required: true
+        type: string
+      solution-version:
+        required: true
+        type: string
+    secrets:
+      FETCH_TOKEN:
+        required: false
+    outputs:
+      artifact-name:
+        description: 'Name of the uploaded build output artifact'
+        value: ${{ jobs.prebuild.outputs.artifact-name }}
+
+permissions:
+  contents: read
+
+jobs:
+  prebuild:
+    name: Prebuild .NET solution
+    runs-on: ${{ inputs.runs-on || 'ubuntu-latest' }}
+
+    outputs:
+      artifact-name: ${{ steps.artifact.outputs.name }}
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        fetch-depth: 1
+        submodules: recursive
+        token: ${{ secrets.FETCH_TOKEN || github.token }}
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+      with:
+        dotnet-version: ${{ inputs.dotnet-version }}
+        global-json-file: ./global.json
+
+    - name: NuGet cache
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props', '**/Directory.Build.props') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
+
+    - name: Restore dependencies
+      run: dotnet restore ${{ inputs.solution }} -v ${{ inputs.dotnet-logging }}
+
+    # Build flags must match the build in step-dotnet-tests.yml exactly, so that
+    # `dotnet test --no-build` in the test jobs runs against identical binaries
+    # and the embedded source paths in the coverage reports stay unchanged.
+    - name: Build
+      run: dotnet build ${{ inputs.solution }} -c Release -v ${{ inputs.dotnet-logging || 'minimal' }} --no-restore /p:GeneratePackageOnBuild=false /p:Version=${{ inputs.solution-version }}
+
+    - name: Determine artifact name
+      id: artifact
+      run: echo "name=prebuilt-output-${{ hashFiles(inputs.solution) }}" >> $GITHUB_OUTPUT
+
+    - name: Pack build output
+      run: |
+        find . -type d \( -name bin -o -name obj \) -not -path './.git/*' -print0 \
+          | tar --zstd -cf prebuilt-output.tzst --null --files-from -
+
+    - name: Upload build output
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ steps.artifact.outputs.name }}
+        if-no-files-found: error
+        retention-days: 1
+        path: prebuilt-output.tzst

--- a/.github/workflows/step-dotnet-tests.yml
+++ b/.github/workflows/step-dotnet-tests.yml
@@ -21,6 +21,10 @@ on:
         required: false
         type: string
         default: default
+      prebuilt-artifact:
+        required: false
+        type: string
+        default: ''
       runs-on:
         required: false
         type: string
@@ -118,7 +122,23 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore ${{ inputs.solution }} -v ${{ inputs.dotnet-logging }}
 
+    # The prebuilt output is only reused on Linux, since the binaries and the
+    # source paths embedded in the coverage reports are produced on a Linux
+    # runner with an identical workspace path. Other runner types build locally.
+    - name: Download prebuilt output
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      if: ${{ inputs.prebuilt-artifact != '' && runner.os == 'Linux' }}
+      with:
+        name: ${{ inputs.prebuilt-artifact }}
+
+    - name: Extract prebuilt output
+      if: ${{ inputs.prebuilt-artifact != '' && runner.os == 'Linux' }}
+      run: |
+        tar --zstd -xf prebuilt-output.tzst
+        rm prebuilt-output.tzst
+
     - name: Build
+      if: ${{ inputs.prebuilt-artifact == '' || runner.os != 'Linux' }}
       run: dotnet build ${{ inputs.solution }} -c Release -v ${{ inputs.dotnet-logging || 'minimal' }} --no-restore /p:GeneratePackageOnBuild=false /p:Version=${{ inputs.solution-version }}
 
     - name: Test


### PR DESCRIPTION
## Motivation

Measured on a recent healthchecks run: every job in the dynamic test matrix builds the full solution (~290 s), on top of the final build job. With 6 test groups that is ~30 agent-minutes of duplicated compilation per PR — the single largest consumer of agent time.

## Changes

### New: `step-dotnet-prebuild.yml`
- Builds the solution once with **exactly the same flags** as the build inside `step-dotnet-tests.yml` (`-c Release /p:GeneratePackageOnBuild=false /p:Version=...`), so `dotnet test --no-build` runs against identical binaries.
- Packs all `bin`/`obj` directories into a single zstd-compressed tar and uploads it as an artifact (1 day retention). A single-file artifact avoids the per-file overhead of upload-artifact on thousands of small files.
- Exposes the artifact name as a workflow output.

### `step-dotnet-tests.yml`
- New optional input `prebuilt-artifact` (default `''` = previous behavior).
- When set **and** the runner is Linux: download + extract the prebuilt output and skip the local build step. Restore still runs (cheap with the NuGet cache) so the package fallback folder and MSBuild imports are in place.
- Windows/macOS matrix legs keep building locally — binaries and embedded source paths are produced per-OS there.

### `build-dotnet-dynamic.yml`
- New `prebuild` job (parallel to `collect`/`format`), gated on Linux tests being enabled.
- `tests` consumes `needs.prebuild.outputs.artifact-name`; when prebuild is skipped the input is empty and behavior is unchanged.
- New `disablePrebuild` input as an escape hatch to restore the previous behavior without a template downgrade.

## Coverage reports are unaffected

- Coverage is produced at **test run time** (`dotnet test --coverage --coverage-output-format cobertura`) in each test job, exactly as before.
- Prebuild and test jobs run on the same runner image with the identical workspace path (`/home/runner/work/<repo>/<repo>`), so the source paths embedded in the Cobertura files are byte-identical to a local build.
- `TestResults` layout, ReportGenerator inputs/outputs, the coverage artifact names, the step summary and the Codecov upload are untouched — downstream tools (Codecov etc.) read the same paths and formats.

## Expected impact (healthchecks numbers)

| | before | after |
|---|---|---|
| per test job | restore 29 s + build ~290 s | restore ~10 s (cached) + download/extract ~60–90 s |
| prebuild job | — | ~6–7 min (once) |
| net agent time per PR | — | **~13–18 min saved** |

Wall clock of the longest chain shifts slightly (tests start after prebuild instead of building themselves) but total agent occupancy — the actual bottleneck with ~20 agents — drops significantly.

## Rollout / verification

1. Merge, tag as usual.
2. Verify on a healthchecks PR: test jobs show "Download prebuilt output" instead of "Build", coverage summary and Codecov status still report identical numbers.
3. If anything misbehaves: set `disablePrebuild: true` in the consumer workflow.

Note: `build-dotnet-matrix.yml` (static matrix) is intentionally left unchanged; it can adopt the same pattern in a follow-up once this has proven itself.