### PR TITLE
fix(ci): don't fail build on codecov upload errors

### DIFF
--- a/.github/workflows/step-dotnet-tests.yml
+++ b/.github/workflows/step-dotnet-tests.yml
@@ -146,7 +146,7 @@ jobs:
       if: ${{ env.codecov_token != '' && (success() || steps.test.conclusion == 'failure') }}
       with:
         token: ${{ env.codecov_token }}
-        fail_ci_if_error: true
+        fail_ci_if_error: false
         files: ${{ github.workspace }}/coveragereports/Cobertura.xml
 
     - name: Upload Coverage Reports


### PR DESCRIPTION
Codecov's GPG signature verification for the CLI binary is currently broken upstream (`gpg: no valid OpenPGP data found` / `No public key`), causing the shared `Run Tests` job to fail on every PR even when all tests pass with 0 errors. This is blocking dependency-bump PRs across the org.

Sets `fail_ci_if_error: false` on the codecov-action step so a coverage-upload hiccup no longer fails CI.