### PR TITLE
fix(ci): remove invalid version input and upload Stryker HTML reports

### DIFF
--- a/.github/workflows/mutation-dotnet.yml
+++ b/.github/workflows/mutation-dotnet.yml
@@ -50,4 +50,13 @@ jobs:
         with:
           configurationFile: ${{ steps.check-config.outputs.path }}
           dashboardApiKey: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
-          version: ${{ github.ref_name }}
+
+      - name: Upload Stryker HTML reports
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: ${{ steps.check-config.outputs.exists == 'true' }}
+        with:
+          name: mutation-report-${{ hashFiles(steps.check-config.outputs.path) }}
+          if-no-files-found: ignore
+          retention-days: 14
+          path: |
+            **/StrykerOutput/**/*.html


### PR DESCRIPTION
## Summary
- Removed the `version` input passed to `lyndychivs/dotnet-stryker-action`, which the action does not support and which caused an annotation warning on every run.
- Added an `actions/upload-artifact` step to publish Stryker mutation HTML reports (`StrykerOutput/**/*.html`), which were previously not persisted anywhere.

## Test plan
- [ ] Trigger `mutation-dotnet.yml` on a repo with a Stryker config and confirm no annotation warning and that the HTML report artifact is attached.